### PR TITLE
Add gosu and entrypoint to jessie-curl

### DIFF
--- a/jessie/curl/Dockerfile
+++ b/jessie/curl/Dockerfile
@@ -1,10 +1,29 @@
 FROM eleidan/debian:jessie
 MAINTAINER Oleg Kulyk
 
-ENV SERVICE_NAME="buildpack-deps:jessie-curl"
+ARG CUSTOM_USER=phantom
+
+ENV SERVICE_NAME="buildpack-deps:jessie-curl" \
+    HOME=/home/$CUSTOM_USER \
+    GOSU_VERSION=1.9
+
+COPY docker-entrypoint.sh /
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		ca-certificates \
-		curl \
-		wget \
-	&& rm -rf /var/lib/apt/lists/*
+      ca-certificates \
+      curl \
+      wget \
+    && rm -rf /var/lib/apt/lists/* \
+    && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
+    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
+    && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu \
+    && gosu nobody true \
+    && useradd -m -s /bin/bash -u 1000 $CUSTOM_USER \
+    && chmod a+x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/jessie/curl/docker-entrypoint.sh
+++ b/jessie/curl/docker-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+THE_USER=phantom
+OLD_UID=$(id -u $THE_USER)
+THE_UID=$OLD_UID
+
+## 1. Fetch UID and GID from /home/phantom/app
+APP_DIR=/home/$THE_USER/app
+if [ -d $APP_DIR ]; then
+  THE_UID=$(stat --format '%u' $APP_DIR)
+  THE_GID=$(stat --format '%g' $APP_DIR)
+fi
+
+## 2. Update UID and GID of the user
+if [[ $OLD_UID != $THE_UID && $THE_UID != "0" ]]; then
+  usermod -u $THE_UID $THE_USER \
+  && groupmod -g $THE_GID $THE_USER \
+  && echo "Updated UID and GID for the '$THE_USER' user according to the '$APP_DIR' directory."
+fi
+
+## 3. Change owner of the files
+if [[ $OLD_UID != $THE_UID && $THE_UID != "0"  ]]; then
+  chown $THE_UID:$THE_GID \
+    $HOME/.bash_customizations \
+    $HOME/.bash_history \
+    $HOME/.bash_logout \
+    $HOME/.bashrc \
+    $HOME/.profile \
+    $HOME \
+    && echo "Updated ownership on $HOME directory according to new UID and GID."
+fi
+
+exec gosu $THE_USER "$@"


### PR DESCRIPTION
The idea is to provide the image with the gosu command.

By default, additional user is created with name 'phantom'
with the UID=1000. This user is used in entrypoint script to execute
provided commands.

The following commands are added to the image:
  - gosu

The following files are added to the image:
  - docker-entrypoint.sh